### PR TITLE
Remove Hector from Operations list

### DIFF
--- a/_data/operations.yml
+++ b/_data/operations.yml
@@ -77,12 +77,6 @@ members:
   - outreach
   name: "Hande K\xFC\xE7\xFCk McGinty"
   orcid: 0000-0002-9025-5538
-- affiliation: La Jolla Institute for Immunology, La Jolla, CA
-  country: USA
-  groups:
-  - outreach
-  name: Hector Guzman-Orozco
-  orcid: 0000-0003-3430-8997
 - affiliation: Knocean Inc., Toronto
   country: Canada
   groups:


### PR DESCRIPTION
Hector is stepping down from the Operations committee, so I am moving him off the `operations.yml` and to the `alumni.yml` lists.